### PR TITLE
feat: update transfer service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 UI/__pycache__/bergamo_rig.cpython-311.pyc
 UI/__pycache__/main_utility.cpython-311.pyc
 UI/__pycache__/metaDataWorker.cpython-311.pyc
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/

--- a/README.md
+++ b/README.md
@@ -26,12 +26,8 @@ Go through all the steps.
 ```
 conda create -n codeocean python=3.11
 conda activate codeocean
-pip install codeocean aind_data_schema_models
-pip install git+https://github.com/AllenNeuralDynamics/aind-data-transfer-service.git
-pip install git+https://github.com/AllenNeuralDynamics/aind-codeocean-pipeline-monitor.git
+pip install codeocean aind_data_schema_models aind-data-transfer-service
 ```
-maybe
-#aind_data_transfer_models, aind_data_transfer_service
 
 ## Install Pybpod and scanimage dependencies
 go somewhere you want these codes to be


### PR DESCRIPTION
Closes #1 

- Adds PyCharm stuff to gitignore
- Changes S3 bucket to `default`, which will put data in the open data bucket
- Uses `default` job_type, which won't run any compression
- Uses new V2 aind-data-transfer-service models